### PR TITLE
Add Whisper transcription via OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flask Upload Example
 
-This repository contains a simple Flask application with an `/upload` endpoint that accepts a video file and saves it locally in the `uploads/` directory.
+This repository contains a simple Flask application with an `/upload` endpoint. The endpoint saves the uploaded video in the `uploads/` directory and transcribes it using the OpenAI Whisper API.
 
 ## Setup
 
@@ -8,6 +8,13 @@ Install the dependencies:
 
 ```bash
 pip install -r requirements.txt
+```
+
+Set the `OPENAI_API_KEY` environment variable before running the server so the
+application can access the Whisper API:
+
+```bash
+export OPENAI_API_KEY=your-key-here
 ```
 
 ## Running the app
@@ -25,5 +32,5 @@ Send a POST request with `multipart/form-data` containing the `file` field:
 ```bash
 curl -F "file=@path/to/video.mp4" http://localhost:5000/upload
 ```
-
-The uploaded file will be stored in the `uploads/` directory.
+The server responds with the JSON transcription result, including the full text
+and timestamped segments. The file is also saved in the `uploads/` directory.

--- a/app.py
+++ b/app.py
@@ -1,9 +1,34 @@
 from flask import Flask, request, jsonify
 import os
 
+try:
+    import openai
+except ImportError:  # pragma: no cover - library may not be installed in CI
+    openai = None
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if openai and OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY
+
 app = Flask(__name__)
 UPLOAD_FOLDER = 'uploads'
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+
+def transcribe_file(file_path: str):
+    """Transcribe the given audio or video file using the Whisper API."""
+    if not openai:
+        return {'error': 'openai library not installed'}
+    if not OPENAI_API_KEY:
+        return {'error': 'OPENAI_API_KEY not set'}
+
+    with open(file_path, 'rb') as audio_file:
+        response = openai.Audio.transcribe(
+            model="whisper-1",
+            file=audio_file,
+            response_format="verbose_json",
+        )
+    return response
 
 @app.route('/upload', methods=['POST'])
 def upload_file():
@@ -14,7 +39,10 @@ def upload_file():
         return jsonify({'error': 'No selected file'}), 400
     file_path = os.path.join(UPLOAD_FOLDER, file.filename)
     file.save(file_path)
-    return jsonify({'message': 'File uploaded', 'path': file_path}), 200
+    transcript = transcribe_file(file_path)
+    if 'error' in transcript:
+        return jsonify(transcript), 500
+    return jsonify(transcript), 200
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+openai


### PR DESCRIPTION
## Summary
- integrate OpenAI Whisper API with `/upload`
- add `openai` dependency
- document the new transcription feature

## Testing
- `python -m py_compile app.py`
- ❌ `pip install openai` *(fails: Tunnel connection failed)*
- ❌ `python -` *(fails: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68846e81852483339caf8d3596d332ce