### PR TITLE
Add spaCy keyword extraction utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,21 @@ curl -F "file=@path/to/video.mp4" http://localhost:5000/upload
 ```
 The server responds with the JSON transcription result, including the full text
 and timestamped segments. The file is also saved in the `uploads/` directory.
+
+## Keyword Extraction
+
+The `keywords.py` module provides an `extract_keywords` function that uses spaCy
+to find the most frequent nouns and verbs in a transcript. Example:
+
+```python
+from keywords import extract_keywords
+
+text = "The quick brown fox jumps over the lazy dog."
+print(extract_keywords(text))
+```
+
+The function requires the `en_core_web_sm` model to be installed:
+
+```bash
+python -m spacy download en_core_web_sm
+```

--- a/keywords.py
+++ b/keywords.py
@@ -1,0 +1,16 @@
+import spacy
+from collections import Counter
+from typing import List
+
+
+def extract_keywords(text: str, n: int = 5) -> List[str]:
+    """Return the top `n` keywords (nouns and verbs) from the given text."""
+    nlp = spacy.load("en_core_web_sm")
+    doc = nlp(text)
+    tokens = [
+        token.lemma_.lower()
+        for token in doc
+        if token.pos_ in ("NOUN", "VERB") and not token.is_stop and token.is_alpha
+    ]
+    counts = Counter(tokens)
+    return [word for word, _ in counts.most_common(n)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 openai
+spacy


### PR DESCRIPTION
## Summary
- add `extract_keywords` function for pulling noun/verb keywords
- document new capability in README
- include `spacy` dependency

## Testing
- `python -m py_compile app.py keywords.py`

------
https://chatgpt.com/codex/tasks/task_e_68846fc2631483338a57afdccd052462