### PR TITLE
Add keyword image fetching with Unsplash

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ The function requires the `en_core_web_sm` model to be installed:
 ```bash
 python -m spacy download en_core_web_sm
 ```
+
+## Unsplash Image Fetching
+
+Set the `UNSPLASH_ACCESS_KEY` environment variable to allow the application to
+retrieve one image from Unsplash for each extracted keyword when uploading a
+file. The `/upload` response will then include a list of keywords and a mapping
+of those keywords to image URLs.
+
+```bash
+export UNSPLASH_ACCESS_KEY=your-unsplash-key
+```

--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
 from flask import Flask, request, jsonify
 import os
 
+from keywords import extract_keywords
+from unsplash import fetch_images
+
 try:
     import openai
 except ImportError:  # pragma: no cover - library may not be installed in CI
@@ -42,7 +45,14 @@ def upload_file():
     transcript = transcribe_file(file_path)
     if 'error' in transcript:
         return jsonify(transcript), 500
-    return jsonify(transcript), 200
+    text = transcript.get('text', '') if isinstance(transcript, dict) else ''
+    keywords = extract_keywords(text) if text else []
+    images = fetch_images(keywords) if keywords else {}
+    return jsonify({
+        'transcript': transcript,
+        'keywords': keywords,
+        'images': images,
+    }), 200
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 openai
 spacy
+requests

--- a/unsplash.py
+++ b/unsplash.py
@@ -1,0 +1,35 @@
+import os
+from typing import List, Dict, Optional
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - requests may not be installed in CI
+    requests = None
+
+UNSPLASH_ACCESS_KEY = os.getenv("UNSPLASH_ACCESS_KEY")
+
+
+def _fetch_image(keyword: str) -> Optional[str]:
+    """Fetch a single image URL for the given keyword using the Unsplash API."""
+    if not (requests and UNSPLASH_ACCESS_KEY):
+        return None
+
+    url = "https://api.unsplash.com/photos/random"
+    headers = {"Authorization": f"Client-ID {UNSPLASH_ACCESS_KEY}"}
+    params = {"query": keyword, "orientation": "landscape"}
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=5)
+    except Exception:
+        return None
+    if resp.status_code != 200:
+        return None
+    data = resp.json()
+    return data.get("urls", {}).get("regular")
+
+
+def fetch_images(keywords: List[str]) -> Dict[str, Optional[str]]:
+    """Return a mapping of each keyword to a single image URL."""
+    images: Dict[str, Optional[str]] = {}
+    for kw in keywords:
+        images[kw] = _fetch_image(kw)
+    return images


### PR DESCRIPTION
## Summary
- integrate Unsplash image lookup in `/upload`
- implement helper module `unsplash.py`
- document Unsplash usage in README
- add `requests` dependency

## Testing
- `python -m py_compile app.py keywords.py unsplash.py`


------
https://chatgpt.com/codex/tasks/task_e_688470dbe7f48333beb1267300d787b6