### PR TITLE
Add keyword toggle component

### DIFF
--- a/frontend/components/KeywordToggleList.js
+++ b/frontend/components/KeywordToggleList.js
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+
+export default function KeywordToggleList({ keywords = [], onChange }) {
+  const [active, setActive] = useState(() => {
+    const initial = {};
+    keywords.forEach((k) => {
+      initial[k] = true;
+    });
+    return initial;
+  });
+
+  const handleToggle = (kw) => {
+    const updated = { ...active, [kw]: !active[kw] };
+    setActive(updated);
+    if (onChange) {
+      onChange(updated);
+    }
+  };
+
+  if (!keywords.length) {
+    return null;
+  }
+
+  return (
+    <div className="keyword-toggle-list">
+      {keywords.map((kw) => (
+        <label key={kw} className="toggle">
+          <input
+            type="checkbox"
+            checked={!!active[kw]}
+            onChange={() => handleToggle(kw)}
+          />
+          <span className="slider" />
+          <span className="label-text">{kw}</span>
+        </label>
+      ))}
+      <style jsx>{`
+        .keyword-toggle-list {
+          margin-top: 1rem;
+        }
+        .toggle {
+          display: flex;
+          align-items: center;
+          margin-bottom: 0.5rem;
+          position: relative;
+          padding-left: 50px;
+          cursor: pointer;
+          user-select: none;
+        }
+        .toggle input {
+          opacity: 0;
+          width: 0;
+          height: 0;
+        }
+        .slider {
+          position: absolute;
+          left: 0;
+          top: 0;
+          width: 40px;
+          height: 20px;
+          background-color: #ccc;
+          border-radius: 20px;
+          transition: background-color 0.2s;
+        }
+        .slider:before {
+          content: '';
+          position: absolute;
+          height: 16px;
+          width: 16px;
+          left: 2px;
+          bottom: 2px;
+          background-color: white;
+          border-radius: 50%;
+          transition: transform 0.2s;
+        }
+        input:checked + .slider {
+          background-color: #2196F3;
+        }
+        input:checked + .slider:before {
+          transform: translateX(20px);
+        }
+        .label-text {
+          margin-left: 0.5rem;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import KeywordToggleList from '../components/KeywordToggleList';
 
 export default function UploadPage() {
   const [videoFile, setVideoFile] = useState(null);
@@ -76,6 +77,8 @@ export default function UploadPage() {
           </div>
         </div>
       )}
+
+      <KeywordToggleList keywords={["nature", "people", "technology"]} />
 
       <style jsx>{`
         .container {


### PR DESCRIPTION
## Summary
- add `KeywordToggleList` component for B-roll keyword selection
- show `KeywordToggleList` on upload page with example keywords

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: E403 Forbidden due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_688474a2632483338bd2768c40b1b19d