### PR TITLE
Add subtitle styling controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,17 @@ of those keywords to image URLs.
 ```bash
 export UNSPLASH_ACCESS_KEY=your-unsplash-key
 ```
+
+## Video Rendering with FFmpeg
+
+The `/render` endpoint accepts subtitle style options which are passed directly
+to FFmpeg. Send a JSON payload containing at least `video` and `subtitles` along
+with optional `fontSize`, `fontColor` and `position` keys:
+
+```bash
+curl -X POST http://localhost:5000/render \
+  -H 'Content-Type: application/json' \
+  -d '{"video": "video.mp4", "subtitles": "captions.srt", "fontSize": 32, "fontColor": "#ff0000", "position": "top"}'
+```
+
+The response contains the path to the rendered video in `static/exports`.

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -8,7 +8,8 @@ export default function UploadPage() {
     fontFamily: 'Arial',
     fontSize: '24',
     color: '#ffffff',
-    backgroundColor: '#00000080'
+    backgroundColor: '#00000080',
+    position: 'bottom'
   });
 
   const handleFileChange = (e) => {
@@ -26,6 +27,25 @@ export default function UploadPage() {
   const handleStyleChange = (e) => {
     const { name, value } = e.target;
     setSubtitleStyle({ ...subtitleStyle, [name]: value });
+  };
+
+  const handleRender = async () => {
+    const payload = {
+      fontSize: subtitleStyle.fontSize,
+      fontColor: subtitleStyle.color,
+      position: subtitleStyle.position,
+      video: 'video.mp4',
+      subtitles: 'subs.srt'
+    };
+    try {
+      await fetch('http://localhost:5000/render', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const videoUrl = videoFile ? URL.createObjectURL(videoFile) : null;
@@ -65,6 +85,15 @@ export default function UploadPage() {
           Background:
           <input type="color" name="backgroundColor" value={subtitleStyle.backgroundColor} onChange={handleStyleChange} />
         </label>
+
+        <label>
+          Position:
+          <select name="position" value={subtitleStyle.position} onChange={handleStyleChange}>
+            <option value="bottom">Bottom</option>
+            <option value="top">Top</option>
+            <option value="center">Center</option>
+          </select>
+        </label>
       </div>
 
       {videoUrl && (
@@ -76,7 +105,10 @@ export default function UploadPage() {
               fontFamily: subtitleStyle.fontFamily,
               fontSize: subtitleStyle.fontSize + 'px',
               color: subtitleStyle.color,
-              backgroundColor: subtitleStyle.backgroundColor
+              backgroundColor: subtitleStyle.backgroundColor,
+              bottom: subtitleStyle.position === 'bottom' ? '10px' : 'auto',
+              top: subtitleStyle.position === 'top' ? '10px' : subtitleStyle.position === 'center' ? '50%' : 'auto',
+              transform: subtitleStyle.position === 'center' ? 'translateY(-50%)' : 'none'
             }}
           >
             Subtitle Preview
@@ -106,6 +138,8 @@ export default function UploadPage() {
         </div>
       </div>
 
+      <button className="render-btn" onClick={handleRender}>Render</button>
+
       <style jsx>{`
         .container {
           padding: 2rem;
@@ -120,7 +154,6 @@ export default function UploadPage() {
         }
         .subtitle-preview {
           position: absolute;
-          bottom: 10px;
           width: 100%;
           text-align: center;
           pointer-events: none;
@@ -137,6 +170,11 @@ export default function UploadPage() {
           height: 80px;
           margin-right: 0.5rem;
           margin-bottom: 0.5rem;
+        }
+        .render-btn {
+          margin-top: 1rem;
+          padding: 0.5rem 1rem;
+          font-size: 1rem;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Summary
- support customizing subtitle style in `compose_video`
- add `/render` endpoint to apply FFmpeg parameters
- document new `/render` API
- include UI controls for font size, color and position

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688479a013608333ad9611ce8fc0b155